### PR TITLE
Fixed targetName for Negatable

### DIFF
--- a/src/core/symbolism.Negatable.scala
+++ b/src/core/symbolism.Negatable.scala
@@ -34,5 +34,5 @@ trait Negatable:
   def negate(operand: Self): Result
 
   extension (operand: Self)
-    @targetName("divide")
+    @targetName("negate")
     inline def `unary_-`: Result = negate(operand)


### PR DESCRIPTION
I've noticed what must have been a copy-paste error in the `@targetName` definition of extension method in `Negatable`. Here is my proposal for a fix.